### PR TITLE
Close dropdown menus consistently

### DIFF
--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/DropdownBoxEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/DropdownBoxEntry.java
@@ -115,6 +115,14 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         selectionElement.topRenderer.isSelected = isSelected;
         selectionElement.menu.isSelected = isSelected;
     }
+
+    @Override
+    public void setFocused(@Nullable GuiEventListener listener) {
+        super.setFocused(listener);
+        if (listener != selectionElement) {
+            updateSelected(false);
+        }
+    }
     
     @NotNull
     public ImmutableList<T> getSelections() {
@@ -164,6 +172,34 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
     @Override
     public boolean mouseScrolled(double double_1, double double_2, double amountX, double amountY) {
         return selectionElement.mouseScrolled(double_1, double_2, amountX, amountY);
+    }
+
+    @Override
+    public boolean mouseClicked(MouseButtonEvent event, boolean doubleClick) {
+        boolean expanded = getMorePossibleHeight() >= 0;
+        if (expanded && !selectionElement.isMouseOver(event.x(), event.y())) {
+            closeMenu();
+        }
+
+        boolean handled = super.mouseClicked(event, doubleClick);
+        if (expanded && handled) {
+            closeMenu();
+        }
+        return handled;
+    }
+
+    @Override
+    public boolean keyPressed(KeyEvent event) {
+        if (getMorePossibleHeight() >= 0 && event.key() == GLFW.GLFW_KEY_ESCAPE) {
+            closeMenu();
+            return true;
+        }
+        return super.keyPressed(event);
+    }
+
+    private void closeMenu() {
+        updateSelected(false);
+        super.setFocused(null);
     }
     
     @Override

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/DropdownBoxEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/DropdownBoxEntry.java
@@ -177,12 +177,14 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
     @Override
     public boolean mouseClicked(MouseButtonEvent event, boolean doubleClick) {
         boolean expanded = getMorePossibleHeight() >= 0;
+        boolean clickedSelection = expanded && (selectionElement.bounds.contains(event.x(), event.y())
+                || selectionElement.menu.children().stream().anyMatch(cell -> cell.isMouseOver(event.x(), event.y())));
         if (expanded && !selectionElement.isMouseOver(event.x(), event.y())) {
             closeMenu();
         }
 
         boolean handled = super.mouseClicked(event, doubleClick);
-        if (expanded && handled) {
+        if (handled && clickedSelection) {
             closeMenu();
         }
         return handled;


### PR DESCRIPTION
## Summary

- close an expanded dropdown after selecting an option
- close it when clicking outside the dropdown or moving focus elsewhere
- make Escape dismiss the menu without accepting the first recommendation
- keep the menu open while using its scrollbar

Closes #112.

## Testing

- `./gradlew :fabric:compileJava :neoforge:compileJava` with JDK 25
- manually verified on Fabric 26.2 using the combined `billstark001:test/dropdown-integration` branch
- checked option selection, outside clicks, Escape, reset/save state, mouse-wheel scrolling, and scrollbar interaction

This implementation was prepared with Codex assistance and manually reviewed and tested by the author.