### PR TITLE
Use selection-only dropdowns for AutoConfig enums

### DIFF
--- a/common/src/main/java/me/shedaniel/autoconfig/annotation/ConfigEntry.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/annotation/ConfigEntry.java
@@ -149,8 +149,12 @@ public class ConfigEntry {
             EnumDisplayOption option() default EnumDisplayOption.DROPDOWN;
             
             enum EnumDisplayOption {
+                /** A selection-only dropdown containing every enum value. */
                 DROPDOWN,
-                BUTTON
+                /** A button that cycles through the enum values. */
+                BUTTON,
+                /** An editable text field that suggests matching enum values. */
+                SUGGESTION
             }
         }
     }

--- a/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiProviders.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiProviders.java
@@ -157,6 +157,7 @@ public class DefaultGuiProviders {
                                             enums,
                                             getUnsafely(field, config, getUnsafely(field, defaults))
                                     )
+                                    .setNameProvider(value -> getEnumName(i18n, value))
                                     .setDefaultValue(() -> getUnsafely(field, defaults))
                                     .setSaveConsumer(newValue -> setUnsafely(field, config, newValue))
                                     .build()
@@ -169,6 +170,9 @@ public class DefaultGuiProviders {
         registry.registerPredicateProvider(
                 (i18n, field, config, defaults, guiProvider) -> {
                     List<Enum<?>> enums = Arrays.asList(((Class<? extends Enum<?>>) field.getType()).getEnumConstants());
+                    Function<Enum<?>, Component> nameProvider = value -> getEnumName(i18n, value);
+                    boolean suggestionMode = field.isAnnotationPresent(ConfigEntry.Gui.EnumHandler.class)
+                            && field.getAnnotation(ConfigEntry.Gui.EnumHandler.class).option() == ConfigEntry.Gui.EnumHandler.EnumDisplayOption.SUGGESTION;
                     return Collections.singletonList(
                             ENTRY_BUILDER.startDropdownMenu(
                                             Component.translatable(i18n),
@@ -177,17 +181,18 @@ public class DefaultGuiProviders {
                                                     str -> {
                                                         String s = Component.literal(str).getString();
                                                         for (Enum<?> constant : enums) {
-                                                            if (DEFAULT_NAME_PROVIDER.apply(constant).getString().equals(s)) {
+                                                            if (nameProvider.apply(constant).getString().equals(s)) {
                                                                 return constant;
                                                             }
                                                         }
                                                         return null;
                                                     },
-                                                    DEFAULT_NAME_PROVIDER
+                                                    nameProvider
                                             ),
-                                            DropdownMenuBuilder.CellCreatorBuilder.of(DEFAULT_NAME_PROVIDER)
+                                            DropdownMenuBuilder.CellCreatorBuilder.of(nameProvider)
                                     )
                                     .setSelections(enums)
+                                    .setSuggestionMode(suggestionMode)
                                     .setDefaultValue(() -> getUnsafely(field, defaults))
                                     .setSaveConsumer(newValue -> setUnsafely(field, config, newValue))
                                     .build()
@@ -523,6 +528,13 @@ public class DefaultGuiProviders {
         return registry;
     }
     
+    private static Component getEnumName(String i18n, Enum<?> value) {
+        String valueKey = i18n + "." + value.name().toLowerCase(Locale.ROOT);
+        return I18n.get(valueKey).equals(valueKey)
+                ? DEFAULT_NAME_PROVIDER.apply(value)
+                : Component.translatable(valueKey);
+    }
+
     private static List<AbstractConfigListEntry> getChildren(String i18n, Field field, Object config, Object defaults, GuiRegistryAccess guiProvider) {
         return getChildren(i18n, field.getType(), getUnsafely(field, config), getUnsafely(field, defaults), guiProvider);
     }


### PR DESCRIPTION
## Summary

- make unannotated and `DROPDOWN` AutoConfig enum fields use selection-only dropdowns
- add `EnumDisplayOption.SUGGESTION` as an explicit opt-in to the existing editable suggestion behavior
- resolve enum labels from `<field translation key>.<lowercase enum name>`
- fall back to the existing `Translatable` / `toString()` name provider when a field-specific translation is absent
- use the same field-specific labels for button and dropdown enum handlers

Closes #130. Related to #131.

## Compatibility

Existing enum serialization is unchanged. Configs that need the previous editable type-ahead control can select `EnumDisplayOption.SUGGESTION` explicitly.

## Testing

- `./gradlew :fabric:compileJava :neoforge:compileJava` with JDK 25
- manually verified on Fabric 26.2 using the combined `billstark001:test/dropdown-integration` branch
- checked default enum dropdowns, button enums, field-specific translations, fallback labels, Reset, and Done edited-state behavior

This implementation was prepared with Codex assistance and manually reviewed and tested by the author.